### PR TITLE
Update Werkzeug to 0.15.5 Fixes runtime typeError

### DIFF
--- a/server/python/requirements.txt
+++ b/server/python/requirements.txt
@@ -11,4 +11,4 @@ requests==2.22.0
 stripe==2.29.3
 toml==0.9.6
 urllib3==1.25.3
-Werkzeug==0.15.4
+Werkzeug==1.0.1


### PR DESCRIPTION
Fixes type error: https://werkzeug.palletsprojects.com/en/1.0.x/changes/#version-0-15-5
Without this, the following traceback is observed:

```
/python/venv/lib/python3.8/site-packages/werkzeug/routing.py", line 951, in _compile_builder
    code = compile(module, "<werkzeug routing>", "exec")
TypeError: required field "type_ignores" missing from Modulew

```