### PR TITLE
Default BASE_PRICE in .env.example to 1000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ STRIPE_WEBHOOK_SECRET=whsec_1234
 
 # Environment variables 
 STATIC_DIR=../../client 
+BASE_PRICE=1000


### PR DESCRIPTION
Without BASE_PRICE being set, it is evaluated to null client side and the price calculation fails when the user increments the quantity.