### PR TITLE
Domain url not set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ STRIPE_WEBHOOK_SECRET=whsec_1234
 
 # Environment variables 
 STATIC_DIR=../../client 
+BASE_PRICE=1000

--- a/server/python/server.py
+++ b/server/python/server.py
@@ -42,7 +42,7 @@ def compute_application_fee_amount(base_price, quantity):
 @app.route('/create-checkout-session', methods=['POST'])
 def create_checkout_session():
     data = json.loads(request.data)
-    domain_url = os.getenv('DOMAIN')
+    domain_url = request.headers['origin']
     quantity = int(data['quantity'])
     base_price = int(os.getenv('BASE_PRICE'))
 


### PR DESCRIPTION
Resolve unsupported operand type(s) for +: NoneType and str

Removed use of os.getenv(DOMAIN) as not needed

Instead, server code is now consistent with other stripe code sample: https://github.com/stripe-samples/connect-onboarding-for-standard/blob/3558b47eedb937effb0edcb8e16b055fb6acfa3f/server/python/server.py#L40